### PR TITLE
Fix port mapping

### DIFF
--- a/portworx-install-docker-standalone-2-6/step2.md
+++ b/portworx-install-docker-standalone-2-6/step2.md
@@ -4,14 +4,14 @@ Install on the node as a docker container:
 
 `export IP=$(hostname -I | awk '{print $1}')`{{execute}} 
 
-Container exposed to host port 4001:
+Container running to host port 2379:
 
-`docker run -d --net=host -p 4001:2379 \
+`docker run -d --net=host \
    --volume=/var/lib/px-etcd:/etcd-data \
    --name etcd quay.io/coreos/etcd /usr/local/bin/etcd \
    --data-dir=/etcd-data --name node1 \
-   --advertise-client-urls http://${IP}:4001 \
-   --listen-client-urls http://${IP}:4001 \
+   --advertise-client-urls http://${IP}:2379 \
+   --listen-client-urls http://${IP}:2379 \
    --initial-advertise-peer-urls http://${IP}:2380 \
    --listen-peer-urls http://${IP}:2380 \
    --initial-cluster node1=http://${IP}:2380`{{execute}}

--- a/portworx-install-docker-standalone-2-6/step4.md
+++ b/portworx-install-docker-standalone-2-6/step4.md
@@ -6,7 +6,7 @@ IP Address of the ETCD Server:
 
 
 `sudo /opt/pwx/bin/px-runc install -c demo-px-cluster \
-    -k etcd://${IP}:4001 \
+    -k etcd://${IP}:2379 \
     -s /dev/vdb`{{execute}} 
 
 Warning: If you make a mistake while running the above command, please clean up the configuration before attempting a re-install.


### PR DESCRIPTION
Port mapping is not available when using host networking (https://docs.docker.com/network/host/)